### PR TITLE
tech: fix missing license header maven error that was thrown when running clean install by doing the license-maven-plugin:format written in pom.xml

### DIFF
--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/CommentService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/CommentService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityLabelService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityLabelService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.common.base.Charsets;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/EntityService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/MetadataService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/MetadataService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.gson.Gson;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/ServiceProxyFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/ServiceProxyFactory.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/TestService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/TestService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.api.client.http.GenericUrl;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/UserService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/BasicConnectionSettingProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/BasicConnectionSettingProvider.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import java.util.ArrayList;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettings.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettings.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.authentication.JSONAuthentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettingsProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/ConnectionSettingsProvider.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 public interface ConnectionSettingsProvider {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/HttpClientProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/HttpClientProvider.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.network.OctaneHttpClient;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/IdePluginsOctaneHttpClient.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/IdePluginsOctaneHttpClient.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.google.api.client.http.*;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/OctaneProvider.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/OctaneProvider.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/UserAuthentication.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/UserAuthentication.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection;
 
 import com.hpe.adm.nga.sdk.authentication.SimpleUserAuthentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/GrantTokenAuthentication.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/GrantTokenAuthentication.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 import com.hpe.adm.nga.sdk.authentication.SimpleClientAuthentication;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompleteHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompleteHandler.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingCompleteHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompletedStatus.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingCompletedStatus.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public class TokenPollingCompletedStatus {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingInProgressHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingInProgressHandler.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingInProgressHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStartedHandler.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStartedHandler.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public interface TokenPollingStartedHandler {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStatus.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/connection/granttoken/TokenPollingStatus.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.connection.granttoken;
 
 public class TokenPollingStatus {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/di/ServiceModule.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.di;
 
 import com.google.common.base.Supplier;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceException.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceException.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.exception;
 
 public class ServiceException extends Exception {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceRuntimeException.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/exception/ServiceRuntimeException.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.exception;
 
 public class ServiceRuntimeException extends RuntimeException {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/Entity.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/Entity.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.filtering;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/PredefinedEntityComparator.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/filtering/PredefinedEntityComparator.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.filtering;
 
 import java.util.Arrays;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/model/EntityModelWrapper.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/model/EntityModelWrapper.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.model;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/model/ReadOnlyEntityModel.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/model/ReadOnlyEntityModel.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.model;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkFilterCriteria.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkFilterCriteria.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/DynamoMyWorkService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP1MyWorkService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/EvertonP2MyWorkService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.common.collect.BiMap;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/IronMaidenP1MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/IronMaidenP1MyWorkService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkServiceProxyFactory.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/mywork/MyWorkUtil.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.mywork;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/CommitMessageService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/CommitMessageService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonArray;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/DownloadScriptService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonParser;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/EntitySearchService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/EntitySearchService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/ImageService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.api.client.http.*;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/OctaneVersionService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/OctaneVersionService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonParser;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/SharedSpaceLevelRequestService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/SharedSpaceLevelRequestService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.gson.JsonArray;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/TimelineService.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/nonentity/TimelineService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.nonentity;
 
 import com.google.inject.Inject;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/AccessLevelValue.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/AccessLevelValue.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/ClientType.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/ClientType.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 public enum ClientType {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/DefaultEntityFieldsUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/DefaultEntityFieldsUtil.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.google.common.base.Charsets;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityTypeIdPair.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityTypeIdPair.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityUtil.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/EntityUtil.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/MyWorkPreviewDefaultFields.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/MyWorkPreviewDefaultFields.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.google.common.base.Charsets;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneSystemDefaultForms.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneSystemDefaultForms.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneUrlBuilder.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneUrlBuilder.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/OctaneVersion.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 public class OctaneVersion implements Comparable<OctaneVersion> {

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/PartialEntity.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/PartialEntity.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/UrlParser.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.google.api.client.util.Charsets;

--- a/src/main/java/com/hpe/adm/octane/ideplugins/services/util/Util.java
+++ b/src/main/java/com/hpe/adm/octane/ideplugins/services/util/Util.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.services.util;
 
 import com.hpe.adm.nga.sdk.model.*;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/Constants.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/Constants.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins;
 
 import com.hpe.adm.octane.ideplugins.services.filtering.Entity;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/TestUtil.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/TestUtil.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins;
 
 import com.hpe.adm.nga.sdk.model.EntityModel;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/DependencyInjectionITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/DependencyInjectionITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/IntegrationTestSuite.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/IntegrationTestSuite.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,8 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests;
 
 import com.hpe.adm.octane.ideplugins.integrationtests.services.*;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/TestServiceModule.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/TestServiceModule.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,8 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/CommentServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/CommentServiceITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/CommitMessageServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/CommitMessageServiceITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/ConnectionSettingsITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/ConnectionSettingsITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityLabelServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityLabelServiceITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/EntityServiceITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/GherkinTestDownloadITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/GherkinTestDownloadITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MetadataServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MetadataServiceITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MyWorkTreeITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/MyWorkTreeITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/RequirementsITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/RequirementsITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/SearchFunctionalityITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/SearchFunctionalityITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services;
 
 import com.google.inject.Guice;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/EntitySearchServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/EntitySearchServiceITCase.java
@@ -1,11 +1,11 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
  * its affiliates and licensors (“Open Text”) are as may be set forth
  * in the express warranty statements accompanying such products and services.
  * Nothing herein should be construed as constituting an additional warranty.
- * Open Text shall not be l302iable for technical or editorial errors or
+ * Open Text shall not be liable for technical or editorial errors or
  * omissions contained herein. The information contained herein is subject
  * to change without notice.
  *
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services.noentity;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/OctaneVersionServiceITCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/services/noentity/OctaneVersionServiceITCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.services.noentity;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/BacklogUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/BacklogUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/EntityUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/EntityUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/MyWorkUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/MyWorkUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/OctaneUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/OctaneUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/PropertyUtil.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/PropertyUtil.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.hpe.adm.octane.ideplugins.services.connection.BasicConnectionSettingProvider;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/ReleaseUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/ReleaseUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/RequirementUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/RequirementUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/RunUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/RunUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/TaskUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/TaskUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/TestUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/TestUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/UserUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/UserUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,8 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
-
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/WorkspaceUtils.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/integrationtests/util/WorkspaceUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.integrationtests.util;
 
 import com.google.inject.Inject;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/DefaultEntityFieldsUtilUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/DefaultEntityFieldsUtilUTCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.unittests;
 
 import com.google.common.base.Charsets;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/OctaneVersionUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/OctaneVersionUTCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.unittests;
 
 import com.hpe.adm.octane.ideplugins.services.util.OctaneVersion;

--- a/src/test/java/com/hpe/adm/octane/ideplugins/unittests/UrlParserUTCase.java
+++ b/src/test/java/com/hpe/adm/octane/ideplugins/unittests/UrlParserUTCase.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/*
  * Copyright 2017-2026 Open Text.
  *
  * The only warranties for products and services of Open Text and
@@ -25,7 +25,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- ******************************************************************************/
+ */
 package com.hpe.adm.octane.ideplugins.unittests;
 
 import com.hpe.adm.octane.ideplugins.services.connection.ConnectionSettings;


### PR DESCRIPTION
fix missing license header maven error that was thrown when running clean install by doing the license-maven-plugin:format written in pom.xml