### PR TITLE
defect #3035375: Add missing my work preview fields for multiple entities

### DIFF
--- a/src/main/resources/myWorkPreviewDefaultFields.json
+++ b/src/main/resources/myWorkPreviewDefaultFields.json
@@ -13,6 +13,7 @@
         "author",
         "story_points",
         "owner",
+        "team",
         "invested_hours",
         "remaining_hours",
         "estimated_hours",
@@ -82,7 +83,9 @@
         "name",
         "subtype",
         "owner",
-        "phase"
+        "phase",
+        "author",
+        "priority"
       ]
     },
     {
@@ -95,7 +98,9 @@
         "phase",
         "duration",
         "start_time",
-        "end_time"
+        "end_time",
+        "parent",
+        "release_process"
       ]
     },
     {


### PR DESCRIPTION
https://center.almoctane.com/ui/entity-navigation?p=1001/1002&entityType=work_item&id=3035375

Problem: Currently, multiple previews from my work do not have relevant or all meaningful fields.
Solution: Added meaningful fields to previews for the new entities.